### PR TITLE
Add secret sync via secrets-manager

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -23,29 +23,29 @@ spec:
         - name: DATABASE_USER
           valueFrom:
             secretKeyRef:
-              name: cloudsql-user-creds
+              name: kernel-service-poc/postgres-db-creds
               key: username
         - name: DATABASE_USER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: cloudsql-user-creds
+              name: kernel-service-poc/postgres-db-creds
               key: password
         - name: DATABASE_NAME
           valueFrom:
             secretKeyRef:
-              name: cloudsql-db-name
-              key: db-name
+              name: kernel-service-poc/postgres-db-name
+              key: name
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.16
         env:
         - name: SQL_INSTANCE_NAME
           valueFrom:
             secretKeyRef:
-              name: cloudsql-instance-name
+              name: postgres-cloudsql-instance-name
               key: name
         command: ["/cloud_sql_proxy",
                   "-instances=terra-kernel-k8s:us-central1:$(SQL_INSTANCE_NAME)=tcp:5432",
-                  "-credential_file=/secrets/cloudsql/sql-creds.json"]
+                  "-credential_file=/secrets/cloudsql/service-account.json"]
         securityContext:
           runAsUser: 2  # non-root user
           allowPrivilegeEscalation: false

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: SQL_INSTANCE_NAME
           valueFrom:
             secretKeyRef:
-              name: postgres-cloudsql-instance-name
+              name: cloudsql-postgres-instance-name
               key: name
         command: ["/cloud_sql_proxy",
                   "-instances=terra-kernel-k8s:us-central1:$(SQL_INSTANCE_NAME)=tcp:5432",


### PR DESCRIPTION
Added secret sync from Vault to k8s with [secrets-manager secret definitions](https://github.com/tuenti/secrets-manager)
It runs in the cluster and monitors secret definitions across the cluster, which are basically maps of Vault secrets to k8s secrets, and updates the k8s secrets if what's in vault changes.

[Framework secrets docs](https://app.gitbook.com/@dsp-security/s/dsp-appsec/~/drafts/-M0wvOqbigrWBOaUw7_P/devops/framework-kernel-new-stack/terra-framework-deployment#secrets)

Changes that go along with this:
- [Add secrets-manager to the cluster](https://github.com/broadinstitute/terra-helm/commit/184b89aed68a94e2242a40babce57e00af5e3911)
- Added new repos, `env-base` and `env-base-config` to capture environment-wide k8s configuration and env-specific overlays. Currently the base contains cloudsql SA and instance name secrets and the env overlays contain namespaces for the environments.
- [Added db name and credentials secrets to the environment overlay, since db name/credentials should vary between envs](https://github.com/DataBiosphere/kernel-service-poc-config/compare/7def4434b1b9c3da5229fd029be195643ce0775f...ea81fd7832f070d8fafeb57976bd4caa50048fbc)
- [Added cloudsql instance name and SA credentials to the env-base base config, since this is a cluster-wide cross-env secret that should exist in all namespaces/envs](https://github.com/DataBiosphere/env-base/compare/ed8c78e34f5cad370f08b5c4284a6a68557d6c3b...c8a3e8056c26928a5ded19255718fca2e3845f3c)
- [Pulled out namespace creation into env-base overlay](https://github.com/DataBiosphere/env-base-config/compare/c752f485ac1bed140f142a7070c01d33be40f865...cf04858193e0d9c2cb22def95c8cf71c0403e48d)