### PR TITLE
Update API definition and swagger-ui file to support in-cluster development

### DIFF
--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -14,3 +14,11 @@ You can now push to the specified environment by running
 skaffold run
 ```
 or by using IntelliJ's Cloud Code integration, which will auto-detect the generated skaffold.yaml file.
+
+In order to use the swagger-ui functionality to execute requests, you'll need to
+locally modify the API definition at `src/resources/api/service_openapi.yaml` by
+adding your url prefix to the `servers` list. Currently, url prefixes are
+`/{environment name}-{service name}`. 
+
+For example, the `kernel-service-poc` 
+service instance in the `dev` environment would have prefix `/dev-kernel-service-poc`.

--- a/src/main/java/bio/terra/TEMPLATE/app/configuration/ApiResourceConfig.java
+++ b/src/main/java/bio/terra/TEMPLATE/app/configuration/ApiResourceConfig.java
@@ -9,9 +9,8 @@ public class ApiResourceConfig implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry
-        .addResourceHandler("/swagger-webjar/**")
-        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.24.0/");
+    registry.addResourceHandler("/api/swagger-webjar/**").addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.24.0/");
+    // registry.addResourceHandler("swagger-webjar/**").addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.24.0/");
     registry.addResourceHandler("/api/**").addResourceLocations("classpath:/api/");
   }
 }

--- a/src/main/java/bio/terra/TEMPLATE/app/configuration/ApiResourceConfig.java
+++ b/src/main/java/bio/terra/TEMPLATE/app/configuration/ApiResourceConfig.java
@@ -9,8 +9,8 @@ public class ApiResourceConfig implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry.addResourceHandler("/api/swagger-webjar/**").addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.24.0/");
-    // registry.addResourceHandler("swagger-webjar/**").addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.24.0/");
+    registry.addResourceHandler("/api/swagger-webjar/**")
+        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.24.0/");
     registry.addResourceHandler("/api/**").addResourceLocations("classpath:/api/");
   }
 }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -8,6 +8,8 @@ info:
   version: 0.0.1
 
 servers:
+  # When developing locally/with Skaffold, add local entry with url prefix here:
+  # E.g. url: /env-kernel-service-poc
   - url: http://localhost:8080
 
 paths:

--- a/src/main/resources/api/swagger-ui.html
+++ b/src/main/resources/api/swagger-ui.html
@@ -4,9 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI</title>
-    <link rel="stylesheet" type="text/css" href="/swagger-webjar/swagger-ui.css" >
-    <link rel="icon" type="image/png" href="/swagger-webjar/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/swagger-webjar/favicon-16x16.png" sizes="16x16" />
+    <link rel="stylesheet" type="text/css" href="swagger-webjar/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="swagger-webjar/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="swagger-webjar/favicon-16x16.png" sizes="16x16" />
     <style>
       html
       {
@@ -33,8 +33,8 @@
   <body>
     <div id="swagger-ui"></div>
 
-    <script src="/swagger-webjar/swagger-ui-bundle.js"> </script>
-    <script src="/swagger-webjar/swagger-ui-standalone-preset.js"> </script>
+    <script src="swagger-webjar/swagger-ui-bundle.js"> </script>
+    <script src="swagger-webjar/swagger-ui-standalone-preset.js"> </script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region


### PR DESCRIPTION
Currently, the URL prefix/substitution system that Istio uses to route requests to services breaks swagger-ui because it specifies resources via absolute paths. This change switches resources to relative paths, allowing the service to serve resources regardless of what URL prefix it uses.