### PR TITLE
PodSecurityPolicy to allow sidecar injector

### DIFF
--- a/config/psp.yaml
+++ b/config/psp.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
-  privileged: true
+  privileged: false
   allowedCapabilities:
     - 'NET_ADMIN'
   seLinux:

--- a/config/psp.yaml
+++ b/config/psp.yaml
@@ -5,7 +5,9 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
-  privileged: false
+  privileged: true
+  allowedCapabilities:
+    - 'NET_ADMIN'
   seLinux:
     rule: RunAsAny
   supplementalGroups:


### PR DESCRIPTION
The current PSP disallow to enable Istio sidecar injector, so we can not use Istio policy. After enable. sidecar injector, I got this error:
unable to validate against any pod security policy: [spec.initContainers[0].securityContext.capabilities.add: Invalid value: "NET_ADMIN": capability may not be added]

And this change should fix that.